### PR TITLE
fix: 对齐对话框标题和左侧图标

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "lew-ui",
-    "version": "1.0.20",
+    "version": "1.0.24",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "lew-ui",
-            "version": "1.0.20",
+            "version": "1.0.24",
             "license": "MIT",
             "dependencies": {
                 "@fancyapps/ui": "^4.0.27",

--- a/packages/directives/dialog/src/LewDialog.vue
+++ b/packages/directives/dialog/src/LewDialog.vue
@@ -236,6 +236,8 @@ const emit = defineEmits(['update:visible']);
             width: 30px;
         }
         .right {
+            position: relative;
+            top: 5px;
             width: 310px;
         }
         main {
@@ -248,6 +250,8 @@ const emit = defineEmits(['update:visible']);
             display: flex;
         }
         .right {
+            position: relative;
+            top: 1px;
             width: 320px;
         }
         .right {


### PR DESCRIPTION
before:
![before](https://user-images.githubusercontent.com/45302571/181598968-7d2512ee-315d-42b3-9c16-42c6e9dcd91b.png)

after:
![after](https://user-images.githubusercontent.com/45302571/181599109-1ed66292-c1d4-4c4d-94c1-b0df96a7a6e1.png)

