### PR TITLE
🐞 fix(button): 修复button的插槽上下不居中的问题

### DIFF
--- a/packages/components/button/src/LewButton.vue
+++ b/packages/components/button/src/LewButton.vue
@@ -108,6 +108,7 @@ const classObject = computed(() => {
 .lew-button-small {
     min-width: 50px;
     height: var(--lew-form-item-height-small);
+    line-height: var(--lew-form-item-height-small);
     padding: 0px 8px;
     font-size: var(--lew-form-font-size-small);
 
@@ -124,6 +125,7 @@ const classObject = computed(() => {
 .lew-button-medium {
     min-width: 60px;
     height: var(--lew-form-item-height-medium);
+    line-height: var(--lew-form-item-height-medium);
     padding: 0px 14px;
     font-size: var(--lew-form-font-size-medium);
 
@@ -139,6 +141,7 @@ const classObject = computed(() => {
 .lew-button-large {
     min-width: 70px;
     height: var(--lew-form-item-height-large);
+    line-height: var(--lew-form-item-height-large);
     padding: 0px 20px;
     font-size: var(--lew-form-font-size-large);
 


### PR DESCRIPTION
demo上的button文字看起来不像上下居中的样子，所以加了line-height