### PR TITLE
chore: add `editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+indent_size = 4


### PR DESCRIPTION
add `editorconfig`
添加`editorconfig`抹平编辑器之间编码风格的差异
![image](https://user-images.githubusercontent.com/49954218/235331474-b3117899-de50-44a7-8194-59e3fb683b45.png)
